### PR TITLE
Issue-1: Gave users with upload permission the ability to view and ap…

### DIFF
--- a/ClassicGuildBankApi/appsettings.json
+++ b/ClassicGuildBankApi/appsettings.json
@@ -5,7 +5,7 @@
     }
   },
   "ConnectionStrings": {
-    "ClassicGuildBankDb": "Server=./SQLEXPRESS;Initial Catalog=ClassicGuildBankDb;Integrated Security=True"
+    "ClassicGuildBankDb": "Server=.\\SQLEXPRESS;Initial Catalog=ClassicGuildBankDb;Integrated Security=True"
   },
   "Patreon": {
     "client_id": "PATREON_CLIENT_ID",

--- a/ClassicGuildBankData/Repositories/GuildBankRepository.cs
+++ b/ClassicGuildBankData/Repositories/GuildBankRepository.cs
@@ -664,12 +664,11 @@ namespace ClassicGuildBankData.Repositories
             if (guild == null)
                 return false;
 
-            return guild.UserId == userId;
+            if (guild.UserId == userId)
+                return true;
 
-            //if (guild.UserId == userId)
-            //    return true;
-
-            //return guild.GuildMembers.Any(m => m.UserId == userId && m.CanUpload);
+            //maybe make this a separate setting in the future?
+            return guild.GuildMembers.Any(m => m.UserId == userId && m.CanUpload);
         }
 
         #endregion

--- a/classic-guild-bank/src/app/components/app/app.component.ts
+++ b/classic-guild-bank/src/app/components/app/app.component.ts
@@ -68,7 +68,9 @@ export class AppComponent implements OnInit {
     this.guildStore.guild$.subscribe( (guild) => {
       var isGuildOwner = guild != null && guild.userIsOwner;
       var userCanUpload = guild != null && guild.userCanUpload;
-      var userCanProcessItemRequests = guild != null && guild.userIsOwner; //guild.userCanProcessItemRequests
+
+      //TODO: Make this a separate setting? Stick with upload permissions for now.
+      var userCanProcessItemRequests = guild != null && (guild.userIsOwner || guild.userCanUpload); //guild.userCanProcessItemRequests 
 
       this._isGuildOwner.next(isGuildOwner);
       this._userCanUpload.next(userCanUpload);


### PR DESCRIPTION
# Description

Users who have access to upload items should also be able to approve item requests as they may have the items which are being requested.

Fixes #1 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Steps to reproduce:
1. Need 2 Users, 1 GM and 1 Non-GM
2. Log in as Non-GM
3. Notice Item requests tab does not show up
4. Log In as GM
5. Grant Upload Permission to other user
6. Log in as Non-GM again
7. Item requests tab is now visible

# Checklist:

- [x] My branch has been rebased onto the `master` branch and all conflicts have been resolved
- [x] My code follows the already established style of this project to the best of my ability
- [x] I have performed a self-review of my own code, removed all non-necessary or debugging code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
